### PR TITLE
HAD-86 Add Released changelog widget and Changelog page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+---
+title: Changelog
+template: changelog.html
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,3 +166,4 @@ nav:
           - contributing/developer-resources/index.md
           - Version System: contributing/developer-resources/version-system.md
           - Current Developers: contributing/developer-resources/current-devs.md
+  - Changelog: changelog.md

--- a/overrides/changelog.html
+++ b/overrides/changelog.html
@@ -1,0 +1,32 @@
+{% extends "main.html" %} {% block tabs %} {{ super() }}
+<style>
+  /* Remove spacing, as we cannot hide it completely */
+  .md-main__inner {
+    margin: 0;
+  }
+
+  /* Hide main content for now */
+  .md-content {
+    display: none;
+  }
+
+  /* Hide table of contents */
+  @media screen and (min-width: 60em) {
+    .md-sidebar--secondary {
+      display: none;
+    }
+  }
+
+  /* Hide navigation */
+  @media screen and (min-width: 76.25em) {
+    .md-sidebar--primary {
+      display: none;
+    }
+  }
+
+  body {
+    background-color: #1e2129;
+  }
+</style>
+<released-page color-scheme="dark" channel-id="156352a6-a4f4-4507-b115-18184f3e4d24"></released-page>
+{% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,6 +1,16 @@
 <!-- Elements added to main will be displayed on all pages -->
 {% extends "base.html" %}
 
+<!-- Add released header tag -->
+{% block extrahead %} {{ super() }}
+<script src="https://embed.released.so/1/embed.js" defer></script>
+{% endblock %}
+
+<!-- Add released widget -->
+{% block content %} {{ super() }}
+<released-widget channel-id="19883fcf-9c0f-45a3-8b50-f67ebca6fbbd"></released-widget>
+{% endblock %}
+
 <!-- Outdated bar -->
 {% block outdated %} You're not viewing the latest version.
 <a href="{{ '../' ~ base_url }}">
@@ -29,5 +39,11 @@
 <strong>
   <a href="/contributing/need-help">We need help! If you have experience in C# or Python we would love to have you help out. Click here for more.</a>
 </strong>
+
+{% endblock %} {% block released_widget %}
+
+<script src="https://embed.released.so/1/embed.js" defer></script>
+
+<released-widget channel-id="19883fcf-9c0f-45a3-8b50-f67ebca6fbbd"></released-widget>
 
 {% endblock %}


### PR DESCRIPTION
# This PR

- Adds Release custom html components to `extrahead` override and added the widget to `content` override
- Adds changelog.md and changelog.html
- Adds new changelog page to navtree in mkdocs.yml