### PR TITLE
HAD-35 Create integration contributing section and fix copyright and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">
   <strong>
     View the documentation 
-    <a href="https://hass-agent.github.io/">here</a>
+    <a href="https://hass-agent.io/">here</a>
   </strong>
 </p>
 <br clear="left" />
@@ -15,27 +15,22 @@
 
 ## Overview
 
-This repository contains all the files used to create [HASS.Agent's documentation](https://hass-agent.github.io/).
+This repository contains all the files used to create [HASS.Agent's documentation](https://hass-agent.io/).
 
 ### Branches
 
-- `main` --> contains the source code
+- `main` --> contains the current "latest" docs version
+- `beta` --> contains the current "beta" docs version
 - `gh-pages` --> deployable (builded) version
 
 ## Deployed Documentation
 
-The documentation is deployed here on github pages, you can view it [here](https://hass-agent.github.io/).
+The documentation is deployed here on github pages, you can view it [here](https://hass-agent.io/).
 
 ## Development / Contributing
 
-> Pleas do **not** submit pull requests to this repo.
-
-If you would like to help out with development or translating of the HASS.Agent application check out our guide [here](https://hass-agent.github.io/latest/contributing/).
+If you would like to help out with development or translating of the HASS.Agent application check out our guide [here](https://hass-agent.io/latest/contributing/).
 
 ### Contributing to the documentation
 
-You can either submit github tickets with the info you want added to the documentation or make the changes yourself. You can submit a ticket for any issues, edits or info you want added to the docs. If you want to make the changes yourself continue reading.
-
-### Editing the docs yourself
-
-Checkout [this](https://hass-agent.github.io/latest/contributing/#helping-out-with-the-documentation) page for information on contributing to the documentation.
+You can either submit github tickets with the info you want added to the documentation or make the changes yourself. You can submit a ticket for any issues, edits or info you want added to the docs. If you want to make the changes yourself checkout [the docs](https://hass-agent.io/latest/contributing/#helping-out-with-the-documentation).

--- a/docs/contributing/developer-resources/version-system.md
+++ b/docs/contributing/developer-resources/version-system.md
@@ -6,22 +6,13 @@
 
 ## Overview
 
-#### HASS.Agent uses TWO main version systems
+#### HASS.Agent is based on one version system
 
-##### Client
+All parts off HASS.Agent use semver to keep track of their versions.
 
-- Client
-- Documentation
+## Summary of SemVer
 
-The client and documentation share a version system to make it easy for users to find documentation for any version.
-
-##### Integration
-
-The integration has its own version system similar to HASS's own system.
-
-## Client/Documentation Versioning
-
-HASS.Agent's client and documentation use a semantic-style version system, however some parts are specific to HASS.Agent, so read on.
+This is a general summary of SemVer and how you will indicate different versions throughout development. You may be tempted to skip this if you know SemVer but don't, because how we indicate dev builds and betas is different to others.
 
 ### Stable release versions
 
@@ -80,7 +71,7 @@ The beta version number is to be incremented whenever a new beta version of the 
 
     The stable version for release should be `2.6.0`
 
-    > The dev team has found bugs and is working on a hotfix. They have completed 2 updates to work on this hotfix
+    > The dev team has found bugs and is working on a hotfix. They are in devlopment of the second hotfix right now.
 
     The current beta version should be `2.6.1-beta.1` (1)
 
@@ -88,7 +79,7 @@ The beta version number is to be incremented whenever a new beta version of the 
 
     The stable release version should be `2.6.1`
 
-1.  We use 1 for the `<beta-version>` here, because development update 1 was .0 and development update 2 was .1
+1.  We use 1 for the `<beta-version>` here, because hotfix 1 was .0 and hotfix 2 was .1
 
 ### Other info
 
@@ -106,3 +97,7 @@ Whenever a "parent" version number is incremented the "children" numbers must be
 The documentation operates on version of just `<major>.<minor>` This will still match the client because no major documentation change will happen during a patch of the HASS.Agent client.
 
 The other difference between this version system and the client's version system is that beta version attributes will not exist. In the documentation if the upcoming release is going to be `1.5.0` and the current beta version is `1.5.0-beta.3` then the docs will have `1.5` with the label/attribute `beta`.
+
+## Relationship between the client and the integration
+
+Both the client and the integration are going to be using SemVer, however it will **not** be the same version. Instead when you checkout the installation for HASS.Agent it will tell you what version of the integration is required. The other thing is that most of the integration's development will be backwards compatible and not move up from version `2`.

--- a/docs/contributing/hass-agent-integration/development-lifecycle.md
+++ b/docs/contributing/hass-agent-integration/development-lifecycle.md
@@ -1,0 +1,43 @@
+# Integration Development Lifecycle
+
+**Here is a good diagram showing the development lifecycle**
+
+```mermaid
+flowchart TD
+  subgraph "Local Directory"
+    repoLocal["Local Repo Folder"]
+  end
+
+  subgraph "HA Dev Container"
+    haContainer["HA Dev Container"]
+  end
+
+  repoLocal -->|Copy files| haContainer
+
+  editFiles(Edit files in HA container and test changes)
+  copyBack(Copy files back to the local repo folder)
+  commitPR(Commit changes and submit a PR to the upstream repo)
+
+  haContainer -->|Begin| editFiles
+  editFiles -->|Complete| copyBack
+  copyBack -->|Submit| commitPR
+
+```
+
+## Events in order
+
+#### Copy files
+
+Make sure the local repo folder is in sync with upstream and then copy the `custom_components` folder from the local repo folder to the `.config` directory.
+
+#### Begin
+
+Start the dev container and start editing files.
+
+#### Complete
+
+Finish testing and editing, and then copy the `custom_components` files back to the local repo folder.
+
+#### Submit
+
+Upload/Commit changes and submit a PR to the github organization.

--- a/docs/contributing/hass-agent-integration/finding-issues.md
+++ b/docs/contributing/hass-agent-integration/finding-issues.md
@@ -1,0 +1,7 @@
+# Finding issues
+
+At the moment the full issue tracker hasn't been finished so for now you will have to DM [drr0x](discord.com/users/638245963240046592){: target="\_blank"} on discord to find out what needs to be worked on in the integration.
+
+!!! note
+
+    The info about the issue tracker and how to view it will be updated here once it is completed.

--- a/docs/contributing/hass-agent-integration/index.md
+++ b/docs/contributing/hass-agent-integration/index.md
@@ -1,1 +1,26 @@
 # Developing the HASS.Agent integration
+
+## Overview
+
+HASS.Agent's integration development is the same as all custom components you will find on HACS. The basic idea is to run a dev container of HA with your dev version of the integration installed. As you code and edit you can test your changes inside of the dev HA. Once your finished you will copy the files to the repo and create a PR.
+
+### Prerequisites
+
+- **Dev HA Container** A docker or other container running with a barebones HA installation just for development. You can get that setup by following the [HA Dev Docs](https://developers.home-assistant.io/docs/development_environment/){: target="\_blank"} guide.
+- **VSCode** is highly recommended because of the simple integration with dev containers and complex workflows for running tasks and interfacing with HASS. It is possible to continue without VSCode and use any text editor but we do not provide tutorials for other editors.
+
+## Github and files
+
+The way git and the local folders get setup is a bit different to the standard way for most python apps, but it's not hard to understand.
+
+### The organization repo
+
+The organization repo is the one found in the [HASS.Agent Githu Organization](https://github.com/hass-agent){: target="\_blank"}, it holds the current version of the integration and is what you will fork from.
+
+### Your repo
+
+You will fork the organization repo and have your own version to do development on, after completing your work you will submit a PR to the organization.
+
+### Local directory
+
+The local files are a bit different to the way you are probably used to. The way it works is by having a folder somewhere that reflects your fork of the repo and then the actual integration inside of the HA dev container. The reason git doesn't just track the folder in the dev container is that stuff like the README and github workflows will cause HA to error. We will go over this in more detail in the [setup](./setup.md) section.

--- a/docs/contributing/hass-agent-integration/setup.md
+++ b/docs/contributing/hass-agent-integration/setup.md
@@ -1,0 +1,26 @@
+# Setting up the local workspace for the integration
+
+## Cloning and forking the repo
+
+1. Start off by going to the [HASS.Agent Integration](https://github.com/hass-agent/integration){: target="\_blank"} repo and creating your own fork.
+2. Clone the files to a directory on your computer
+3. Copy the `custom_components` directory
+4. Open your [dev container](#dev-container) files
+5. Paste the `custom_components` directory into the `.config` directory
+6. [Start](#start-ha) the dev container
+
+### Finishing up
+
+You can verify this has worked by going to the integrations page and looking for HASS.Agent Integration
+
+## Reference
+
+### Dev Container
+
+#### Open the container to view files
+
+If you open up the vscode project with your dev HA you will automatically be opened to the dev container's files.
+
+#### Start HA
+
+To start HA in VSCode you can use ++ctrl+shift+p++, and then search for `run task` and then search for `run home assistant core`. This will startup the container on the port(default is 8123)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ repo_name: HASS.Agent Docs Repo
 edit_uri: edit/beta/docs/
 
 copyright: >
-  Copyright &copy; 2023 <a href="https://github.com/DrR0X-glitch" target="_blank" rel="noopener">DrR0x</a> -
+  Copyright &copy; 2023 <a href="https://github.com/hass-agent" target="_blank" rel="noopener">HASS.Agent Team</a> -
   <a href="#__consent">Change cookie settings</a>
 
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
+  - pymdownx.keys
   - admonition
   - pymdownx.arithmatex:
       generic: true
@@ -152,6 +153,9 @@ nav:
           - contributing/hass-agent-app/index.md
       - Developing the Integration:
           - contributing/hass-agent-integration/index.md
+          - Setup: contributing/hass-agent-integration/setup.md
+          - Development Lifecycle: contributing/hass-agent-integration/development-lifecycle.md
+          - What to work on: contributing/hass-agent-integration/finding-issues.md
       - Developing the Documentation:
           - contributing/hass-agent-documentation/index.md
           - Easy Editing: contributing/hass-agent-documentation/easy-editing.md


### PR DESCRIPTION
# This PR

## New pages
- Integration dev homepage
- Integration dev setup
- Integration dev lifecycle
- Integration issue tracker

## Modified Pages
- Version page - includes integration info now

## mkdocs.yml
- Changed copyright to hass.agent team with org link
- Added keys library for keyboard shortcuts
- Added new pages

## Other files
- README
  - Update links to hass-agent.io